### PR TITLE
Remove special characters from title when creating image file name; Fix ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 === Automatic Featured Images from Videos ===
+
 Contributors: bradparbs, coreymcollins, jtsternberg, webdevstudios
 Donate link: http://webdevstudios.com/
 Tags: video, youtube, vimeo, featured image
 Requires at least: 3.7
-Tested up to: 3.9
-Stable tag: 1.0
+Tested up to: 4.1
+Stable tag: 1.0.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -35,6 +36,10 @@ In addition, after setting the video thumbnail as the featured image, an “is_v
 == Screenshots ==
 
 == Changelog ==
+
+= 1.0.1 =
+* Fix bug with special characters in YouTube video titles
+* Fix bug where duplicate images would be uploaded and set as featured image when editing a post
 
 = 1.0 =
 * Initial release


### PR DESCRIPTION
...bug where featured images were being uploaded and set any time a post was edited.